### PR TITLE
[common] add cronjob apiVersion

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between Fluid Truck charts. This chart is not deployable by itself.
 # Please make sure that version and appVersion are always the same.
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.1.0
+appVersion: 1.1.0
 type: library
 keywords:
   - common

--- a/charts/common/templates/_capabilities.tpl
+++ b/charts/common/templates/_capabilities.tpl
@@ -47,3 +47,14 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CronJob.
+*/}}
+{{- define "common.capabilities.cronjob.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
This adds the ability to do the following for `kind: CronJob`:

```
apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
```