### PR TITLE
[golang] check for extra tls

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/frontendconfig-force-https.yaml
+++ b/charts/golang/templates/frontendconfig-force-https.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ingress.tls .Values.ingress.installGCEFrontendConfig }}
+{{- if and .Values.ingress.enabled .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.installGCEFrontendConfig }}
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   {{- if or .Values.ingress.clusterIssuer .Values.ingress.installGCEFrontendConfig .Values.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.ingress.tls }}
+    {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
     {{- if .Values.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
     {{- end }}


### PR DESCRIPTION
When setting up our single service repos on stage we want to generate a single certificate that serves the following hosts:

- `{namespace}.fluidtruck.io`
- `*.{namespace}.fluidtruck.io`

To accomplish this, the pipeline will use the following ingress configs:

**PR:**
```
ingress:
  enabled: true
  hostname: "{{ .Release.Name }}.{{ .Release.Namespace }}.fluidtruck.io"
  extraTls:
  - hosts:
    - "{{ .Release.Namespace }}.fluidtruck.io"
    - "*.{{ .Release.Namespace }}.fluidtruck.io"
    secretName: "{{ .Release.Namespace }}-tls"
```

**Stage:**
```
ingress:
  enabled: true
  hostname: "stage.{{ .Release.Namespace }}.fluidtruck.io"
  extraTls:
  - hosts:
    - "{{ .Release.Namespace }}.fluidtruck.io"
    - "*.{{ .Release.Namespace }}.fluidtruck.io"
    secretName: "{{ .Release.Namespace }}-tls"
```

**Prod:**
```
ingress:
  enabled: true
  tls: true
  hostname: "{{ .Release.Namespace }}.fluidtruck.io"
```

PR/Stage will use the same TLS cert for the static environment, as well as all PRs, so we're only generating one certificate for everything under that namespace. This prevents us from blowing through Cert Manager quotas.

Prod will have a single cert for the production FQDN.