### PR TITLE
[golang] fixes to allow for better env templating

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.2.0
 type: application
 keywords:

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- printf "vault.hashicorp.com/agent-inject-secret-%s: \"%s\"" .name .path | nindent 8 }}
         {{- printf "vault.hashicorp.com/agent-inject-template-%s: |" .name | nindent 8 }}
           {{ printf "{{- with secret \"%s\" -}}" .path }}
-          {{ .value }}
+          {{ .value | indent 10 | trim  }}
           {{ printf "{{- end -}}" }}
         {{- end }}
         {{- end }}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- printf "vault.hashicorp.com/agent-inject-secret-%s: \"%s\"" .name .path | nindent 8 }}
         {{- printf "vault.hashicorp.com/agent-inject-template-%s: |" .name | nindent 8 }}
           {{ printf "{{- with secret \"%s\" -}}" .path }}
-          {{ .value | indent 10 | trim  }}
+          {{ .value | default (printf "{{- range $k, $v := .Data.data -}}\n   {{ $k }}={{ $v }}\n{{ end -}}") | indent 10 | trim  }}
           {{ printf "{{- end -}}" }}
         {{- end }}
         {{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -164,16 +164,23 @@ resources:
 vault:
   enabled: false
   secrets: []
+    # The below example will use a standardized template
+    # that injects a file formatted in a way that allows
+    # libraries like Viper, or dotenv, to load the file at
+    # runtime.
+    #
+    # - name: env
+    #   path: "devops/go-demo/data/prod/env"
+
+    # The below example shows you how to build your own
+    # template value for the injected Vault file.
+    #
     # - name: env
     #   path: "devops/go-demo/prod/secret/data/env"
     #   value: |-
     #     {{- range $k, $v := .Data.data -}}
-    #        {{ $k }}={{ $v }}
+    #        export {{ $k }}="{{ $v }}"
     #     {{ end -}}
-    # - name: db-creds
-    #   path: "secret/data/db"
-    #   value: |-
-    #     export POSTGRES_URL="postgresql://{{ .Data.data.PGUSER }}:{{ .Data.data.PGPASSWORD }}@postgres/{{ .Data.data.PGDATABASE }}"
 
 ## NextJS Deployment update strategy
 ## ref: https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/deployment-v1/#DeploymentSpec

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -165,9 +165,11 @@ vault:
   enabled: false
   secrets: []
     # - name: env
-    #   path: "secret/data/env"
+    #   path: "devops/go-demo/prod/secret/data/env"
     #   value: |-
-    #     export NEWRELIC_LICENSE="{{ .Data.data.NEWRELIC_LICENSE }}"
+    #     {{- range $k, $v := .Data.data -}}
+    #        {{ $k }}={{ $v }}
+    #     {{- end -}}
     # - name: db-creds
     #   path: "secret/data/db"
     #   value: |-

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -169,7 +169,7 @@ vault:
     #   value: |-
     #     {{- range $k, $v := .Data.data -}}
     #        {{ $k }}={{ $v }}
-    #     {{- end -}}
+    #     {{ end -}}
     # - name: db-creds
     #   path: "secret/data/db"
     #   value: |-


### PR DESCRIPTION
Updates helm chart to allow multiline templates and updates the example
to point to a more likely example secret path, and a template that can
take any number of env vars contained in the `env` secret and render
them appropriately.