### PR TITLE
[golang] default to 8090

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 1.2.1
-appVersion: 1.2.0
+version: 2.0.0
+appVersion: 2.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -154,11 +154,13 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.applicationPort }}
+            - name: health
+              containerPort: 8080
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: http
+              port: health
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -169,7 +171,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: http
+              port: health
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -38,7 +38,7 @@ replicaCount: 1
 
 ## Specify the port where your application will be running
 ##
-applicationPort: 8080
+applicationPort: 8090
 
 ## Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
Under the hood, our developer's microservices will be using Port 8090 from their containers to serve gRPC, and port 8080 to serve health checks. So we can remove one more configuration requirement (`applicationPort`) from their end, we will now default to 8090.

In doing so, I created a new container port called health, which exposes 8080 specifically for their readiness and liveness checks.