### PR TITLE
[golang] use namespace for vault.role

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.0.0
-appVersion: 2.0.0
+version: 2.0.1
+appVersion: 2.0.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.vault.enabled }}
-        vault.hashicorp.com/role: {{ include "common.names.fullname" . }}
+        vault.hashicorp.com/role: {{ tpl .Values.vault.role . | quote }}
         vault.hashicorp.com/agent-inject: "true"
         {{- range .Values.vault.secrets -}}
         {{- printf "vault.hashicorp.com/agent-inject-secret-%s: \"%s\"" .name .path | nindent 8 }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -163,6 +163,7 @@ resources:
 ##
 vault:
   enabled: false
+  role: '{{ .Release.Namespace }}'
   secrets: []
     # The below example will use a standardized template
     # that injects a file formatted in a way that allows


### PR DESCRIPTION
This will default to using `.Release.Namespace`, but can be overridden. 