### PR TITLE
[golang] Fix mismatched service account names

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.0.1
-appVersion: 2.0.1
+version: 2.0.2
+appVersion: 2.0.2
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "common.names.fullname" . }}
+      serviceAccountName: {{ tpl .Values.vault.role . | quote }}
       {{- if or (eq "true" (include "golang.waitForRedis" .)) (eq "true" (include "golang.waitForPostgresql" .)) }}
       initContainers:
         {{- if eq "true" (include "golang.waitForRedis" .) }}

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ tpl .Values.vault.role . | quote }}


### PR DESCRIPTION
Fixes a mismatch between the k8s SA name and the bound SA that's created
by the Vault scaffolder action.