### PR TITLE
[golang] Fix example Vault paths

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.0.3
+appVersion: 2.0.3
 type: application
 keywords:
   - go

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -177,7 +177,7 @@ vault:
     # template value for the injected Vault file.
     #
     # - name: env
-    #   path: "devops/go-demo/prod/secret/data/env"
+    #   path: "devops/go-demo/data/prod/env"
     #   value: |-
     #     {{- range $k, $v := .Data.data -}}
     #        export {{ $k }}="{{ $v }}"


### PR DESCRIPTION
We've opted for a single key-value store per-service instead of a
key-value store per environment, update the examples to match.