### PR TITLE
[golang] Revert change to SA naming

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.0.3
-appVersion: 2.0.3
+version: 2.0.4
+appVersion: 2.0.4
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ tpl .Values.vault.role . | quote }}
+      serviceAccountName: {{ include "common.names.fullname" . }}
       {{- if or (eq "true" (include "golang.waitForRedis" .)) (eq "true" (include "golang.waitForPostgresql" .)) }}
       initContainers:
         {{- if eq "true" (include "golang.waitForRedis" .) }}

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ tpl .Values.vault.role . | quote }}
+  name: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
Reverts the change to SA naming convention to avoid clashing names in
staging and instead setting Vault to accept any kubernetes service
account name in the auth method.