### PR TITLE
[golang] add missing export

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,43 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+  name: helm-charts
+  description: Fluid Truck's Helm Charts
+  homepage: https://github.com/fluidtruck/helm-charts
+  default_branch: main
+
+  has_issues: false
+  has_wiki: false
+  has_downloads: false
+
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: false
+  allow_auto_merge: false
+  delete_brach_on_merge: true
+
+collaborators:
+  - username: fluid-devbot
+    permission: admin
+
+teams:
+  - name: devops
+    permission: push
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+      required_status_checks:
+        strict: true
+        contexts:
+          - boost-security-scan
+          - lint
+          - test
+          - title
+      enforce_admins: true
+      required_linear_history: true
+      restrictions:
+        users: [fluid-devbot]
+        teams: [devops]

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.0.4
-appVersion: 2.0.4
+version: 2.0.5
+appVersion: 2.0.5
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- printf "vault.hashicorp.com/agent-inject-secret-%s: \"%s\"" .name .path | nindent 8 }}
         {{- printf "vault.hashicorp.com/agent-inject-template-%s: |" .name | nindent 8 }}
           {{ printf "{{- with secret \"%s\" -}}" .path }}
-          {{ .value | default (printf "{{- range $k, $v := .Data.data -}}\n   {{ $k }}={{ $v }}\n{{ end -}}") | indent 10 | trim  }}
+          {{ .value | default (printf "{{- range $k, $v := .Data.data -}}\n   export {{ $k }}={{ $v }}\n{{ end -}}") | indent 10 | trim  }}
           {{ printf "{{- end -}}" }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
I noticed your PR fluidtruck/backstage#78 and realized the annotation being deployed on trip-scorer was missing `export`. 