### PR TITLE
feat(golang): add http-legacy service port

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.1.2
-appVersion: 2.1.2
+version: 2.2.0
+appVersion: 2.2.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/service.yaml
+++ b/charts/golang/templates/service.yaml
@@ -36,4 +36,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    - name: http-legacy
+      port: 8090
+      targetPort: http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
For our legacy cluster, we need to support `8090` on the service as well. We can remove this once all services are migrated and there are no more references to `8090` in ConfigMap/EnvVar definitions.