### PR TITLE
fix(golang): use null nodePort when using ClusterIP

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.2.1
+appVersion: 2.2.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/service.yaml
+++ b/charts/golang/templates/service.yaml
@@ -39,4 +39,7 @@ spec:
     - name: http-legacy
       port: 8090
       targetPort: http
+      {{- if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
This was discovered by trying to upgrade `legacy-apps-stage` -> `telematics`. Previously, the service used [`type: NodePort`](https://github.com/fluidshare/telematics-domain/blob/main/telematics/chart/stage.yaml#L9-L10). By setting `type: ClusterIP`, we were getting the following error:

```
Error: UPGRADE FAILED: an error occurred while rolling back the release. original upgrade error: cannot patch “telematics-golang” with kind Service: Service “telematics-golang” is invalid: spec.ports[1].nodePort: Forbidden: may not be used when `type` is ‘ClusterIP’: release telematics failed: timed out waiting for the condition
```

This ensures that `nodePort: null` is set under this circumstance. This allows the service to flip from `NodePort` to `ClusterIP` with no issue.