### PR TITLE
feat(golang): add ingressClass support

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.2.1
-appVersion: 2.2.1
+version: 2.3.0
+appVersion: 2.3.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- if .Values.ingress.installGCEFrontendConfig }}
     networking.gke.io/v1beta1.FrontendConfig: force-https
     {{- end }}
+    {{- if .Values.ingress.ingressClass }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.ingressClass }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -252,6 +252,10 @@ ingress:
   ##
   # clusterIssuer: "letsencrypt-staging"
 
+  ## Set this to the required ingressClass. Set to false to use your cluster's default ingress.
+  ##
+  ingressClass: nginx
+
   ## Ingress Path type
   ##
   pathType: ImplementationSpecific


### PR DESCRIPTION
This adds `ingressClass` support to `golang`. Defaulted to `nginx`. If set to `false`, this can be disabled and will use the cluster's default Ingress.