### PR TITLE
feat(golang): improve ingress support

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 2.3.0
-appVersion: 2.3.0
+version: 3.0.0
+appVersion: 3.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-ingress-wildcard-values.yaml
+++ b/charts/golang/ci/with-ingress-wildcard-values.yaml
@@ -1,6 +1,6 @@
 ingress:
   enabled: true
-  hostname: "{{ .Release.Name }}.local"
+  domain: test.local
   tls:
     enabled: true
     issuer: "testing"

--- a/charts/golang/templates/NOTES.txt
+++ b/charts/golang/templates/NOTES.txt
@@ -1,28 +1,20 @@
-1. Get the URL of your Golang app by running:
-
 {{- if .Values.ingress.enabled }}
-
-  echo "Node app URL: http://{{ .Values.ingress.hostname }}"
-
-{{- else if eq .Values.service.type "NodePort" }}
-
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "Node app URL: http://$NODE_IP:$NODE_PORT/"
-
-{{- else if eq .Values.service.type "LoadBalancer" }}
-
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc -w {{ template "common.names.fullname" . }} --namespace {{ .Release.Namespace }}'
-
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo "Node app URL: http://$SERVICE_IP/"
-
-{{- else if eq .Values.service.type "ClusterIP" }}
-
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
-  echo "Node app URL: http://127.0.0.1:{{ .Values.service.port }}/"
+{{- $protocol := ternary "https" "http" .Values.ingress.tls.enabled }}
+To access your application using your browser, open the following URL(s):
+{{ if .Values.ingress.hostname }}
+  {{ $protocol }}://{{ tpl .Values.ingress.hostname . }}
+{{- else }}
+  {{ $protocol }}://{{ include "golang.ingressHostname" . }}
+{{- end }}
 
 {{- end }}
+
+To access your application using kubectl port forwarding, use the following command:
+
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 8080:{{ .Values.service.port }}
+
+Then access your application using your browser, open the following URL:
+
+  http://127.0.0.1:8080
 
 {{- include "golang.validateValues" . }}

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -22,7 +22,7 @@ Compile all warnings into a single message, and call fail.
 
 {{- if $message -}}
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}\
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -44,7 +44,7 @@ Usage:
 {{ include "golang.postgresqlHost" . }}
 */}}
 {{- define "golang.postgresqlHost" -}}
-{{- printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace | quote -}}
+{{- printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
 {{- end -}}
 
 {{/*
@@ -66,5 +66,23 @@ Usage:
 {{ include "golang.redisHost" . }}
 */}}
 {{- define "golang.redisHost" -}}
-{{- printf "%s-redis-master.%s.svc.cluster.local" .Release.Name .Release.Namespace | quote -}}
+{{- printf "%s-redis-master.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Print root hostname to be used other place.
+Usage:
+{{ include "golang.ingressRootHostname" . }}
+*/}}
+{{- define "golang.ingressRootHostname" -}}
+{{- printf "%s.%s" .Release.Namespace .Values.ingress.domain -}}
+{{- end -}}
+
+{{/*
+Print hostname for the ingress.
+Usage:
+{{ include "golang.ingressHostname" . }}
+*/}}
+{{- define "golang.ingressHostname" -}}
+{{- printf "%s.%s" .Release.Name (include "golang.ingressRootHostname" .) -}}
 {{- end -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           image: redis:alpine
           env:
             - name: REDIS_HOST
-              value: {{ include "golang.redisHost" . }}
+              value: {{ include "golang.redisHost" . | quote }}
             - name: REDIS_PORT
               value: "6379"
             - name: REDISCLI_AUTH
@@ -88,7 +88,7 @@ spec:
           image: postgres:alpine
           env:
             - name: POSTGRESQL_HOST
-              value: {{ include "golang.postgresqlHost" . }}
+              value: {{ include "golang.postgresqlHost" . | quote }}
             - name: POSTGRESQL_USERNAME
               value: {{ .Values.postgresql.postgresqlUsername }}
             - name: POSTGRESQL_PASSWORD
@@ -113,7 +113,7 @@ spec:
           env:
             {{- if .Values.redis.enabled }}
             - name: REDIS_HOST
-              value: {{ include "golang.redisHost" . }}
+              value: {{ include "golang.redisHost" . | quote }}
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD
@@ -124,7 +124,7 @@ spec:
             {{- end }}
             {{- if .Values.postgresql.enabled }}
             - name: POSTGRESQL_HOST
-              value: {{ include "golang.postgresqlHost" . }}
+              value: {{ include "golang.postgresqlHost" . | quote }}
             - name: POSTGRESQL_PORT
               value: "5432"
             - name: POSTGRESQL_PASSWORD

--- a/charts/golang/templates/frontendconfig-force-https.yaml
+++ b/charts/golang/templates/frontendconfig-force-https.yaml
@@ -1,9 +1,0 @@
-{{- if and .Values.ingress.enabled .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.installGCEFrontendConfig }}
-apiVersion: networking.gke.io/v1beta1
-kind: FrontendConfig
-metadata:
-  name: force-https
-spec:
-  redirectToHttps:
-    enabled: true
-{{- end }}

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -7,18 +7,13 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.ingress.clusterIssuer .Values.ingress.installGCEFrontendConfig .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- if or .Values.ingress.tls.enabled .Values.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
-    {{- if .Values.ingress.clusterIssuer }}
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
+    {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.issuer | quote }}
     {{- end }}
-    {{- if .Values.ingress.installGCEFrontendConfig }}
-    networking.gke.io/v1beta1.FrontendConfig: force-https
-    {{- end }}
-    {{- if .Values.ingress.ingressClass }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.ingressClass }}
-    {{- end }}
+    {{- if .Values.ingress.class }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
@@ -33,9 +28,15 @@ spec:
     - host: {{ tpl .Values.ingress.hostname . | quote }}
       http:
         paths:
-          {{- if .Values.ingress.extraPaths }}
-          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
-          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- else }}
+    - host: {{ include "golang.ingressHostname" . | quote }}
+      http:
+        paths:
           - path: {{ .Values.ingress.path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
@@ -43,27 +44,24 @@ spec:
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ tpl .name . | quote }}
+    - host: {{ tpl .name $ | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
-    {{- if .Values.ingress.tls }}
     - hosts:
+      {{- if .Values.ingress.hostname }}
       - {{ tpl .Values.ingress.hostname . | quote }}
-      {{- range .Values.ingress.extraHosts }}
-      - {{ .name }}
+      secretName: {{ printf "%s-tls" .Release.Namespace | replace "." "-" }}
+      {{- else }}
+      - {{ printf "*.%s" (include "golang.ingressRootHostname" .) | quote }}
+      secretName: {{ printf "%s-wildcard-tls" .Release.Namespace | replace "." "-" }}
       {{- end }}
-      secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) | replace "." "-" }}
-    {{- end }}
-    {{- if .Values.ingress.extraTls }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -248,88 +248,47 @@ ingress:
   ##
   enabled: false
 
-  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ## Set this to the required desired IngressClass. Set to false to use your cluster's default ingress.
   ##
-  # clusterIssuer: "letsencrypt-staging"
+  class: nginx
 
-  ## Set this to the required ingressClass. Set to false to use your cluster's default ingress.
+  ## Set this to a specific hostname, and the automatic hostname creations will be skipped.
   ##
-  ingressClass: nginx
+  # hostname: my-app.fluiddev.io
 
-  ## Ingress Path type
+  ## Set this to the domain you want to use.
   ##
-  pathType: ImplementationSpecific
-
-  ## Override API Version (automatically detected if not set)
-  ##
-  # apiVersion:
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  ##
-  hostname: golang.local
+  domain: fluiddev.io
 
   ## The Path to Node.js. You may need to set this to '/*' in order to use this
   ## with ALB ingress controllers.
   ##
   path: /
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## Configure TLS
+  ##
+  tls:
+    ## Set this to true to enable TLS
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    issuer: "letsencrypt-staging"
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  # apiVersion:
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  ##
   annotations: {}
-
-  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
-  ##
-  tls: false
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## extraHosts:
-  ## - name: node.local
-  ##   path: /
-  ##
-
-  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
-  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
-  ## extraPaths:
-  ## - path: /*
-  ##   backend:
-  ##     serviceName: ssl-redirect
-  ##     servicePort: use-annotation
-  ##
-
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## extraTls:
-  ## - hosts:
-  ##     - node.local
-  ##   secretName: node.local-tls
-  ##
-
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  ##
-  secrets: []
-  ## - name: node.local-tls
-  ##   key:
-  ##   certificate:
-  ##
-
-  ## Set to true to install the GCE frontend config.
-  ##
-  installGCEFrontendConfig: false
 
 ## Configure the hpa resource that enables autoscaling of the deployment
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
This PR was originally for External DNS, but I feel the API for this new implementation is a little easier to manage down in the dev chart values files; as we control fancy structure here in the chart.

## Domain Mode

By using the `domain` key, we will automatically piece together a URL based on the `.Release.Name` and `.Release.Namespace`values given to the chart; suffixed with the set `domain`.

```yaml
ingress:
  enabled: true
  domain: fluiddev.io
  tls:
    enabled: true
    issuer: letsencrypt-production
```

Assuming you run `helm install my-feature fluidtruck/golang --namespace my-service -f ./values.yaml` you will get the following results:

### Ingress Hosts

- `my-feature.my-service.fluiddev.io`

### TLS Hosts

- `*.my-service.fluiddev.io`

## Hostname Mode

Instead of providing `domain`, you can provide `hostname` which is more declarative. This will force the Ingress, and TLS, to this given value.

```yaml
ingress:
  enabled: true
  hostname: my-service.stage.fluidtruck.io
  tls:
    enabled: true
    issuer: letsencrypt-production
```

Assuming you run `helm install my-service fluidtruck/golang --namespace my-service  -f ./values.yaml` you will get the following results:

### Ingress Hosts

- `my-service.stage.fluidtruck.io`

### TLS Hosts

- `my-service.stage.fluidtruck.io`