### PR TITLE
feat(golang)!: use DB_*

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 3.0.0
-appVersion: 3.0.0
+version: 4.0.0
+appVersion: 4.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $dbHost := include "golang.postgresqlHost" . -}}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -87,15 +88,12 @@ spec:
         - name: wait-for-postgresql
           image: postgres:alpine
           env:
-            - name: POSTGRESQL_HOST
-              value: {{ include "golang.postgresqlHost" . | quote }}
-            - name: POSTGRESQL_USERNAME
+            - name: DB_HOST
+              value: {{ $dbHost }}
+            - name: DB_DATABASE
+              value: {{ .Values.postgresql.postgresqlDatabase }}
+            - name: DB_USER
               value: {{ .Values.postgresql.postgresqlUsername }}
-            - name: POSTGRESQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
-                  key: postgresql-password
           args:
             - /mnt/postgresql/wait-for-postgresql.sh
           volumeMounts:
@@ -123,15 +121,19 @@ spec:
                   key: redis-password
             {{- end }}
             {{- if .Values.postgresql.enabled }}
-            - name: POSTGRESQL_HOST
-              value: {{ include "golang.postgresqlHost" . | quote }}
-            - name: POSTGRESQL_PORT
-              value: "5432"
-            - name: POSTGRESQL_PASSWORD
+            - name: DB_HOST
+              value: {{ $dbHost }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.postgresqlUsername }}
+            - name: DB_DATABASE
+              value: {{ .Values.postgresql.postgresqlDatabase }}
+            - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-postgresql
                   key: postgresql-password
+            - name: DB_URL
+              value: postgress://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):5432/$(DB_DATABASE)
             {{- end }}
             {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}

--- a/charts/golang/templates/postgresql/wait-for-postgresql.yaml
+++ b/charts/golang/templates/postgresql/wait-for-postgresql.yaml
@@ -12,13 +12,13 @@ data:
     #/bin/sh
 
     set -x;
-    echo "Waiting for Postgres on ${POSTGRESQL_HOST}"
+    echo "Waiting for Postgres on ${DB_HOST}"
 
     ATTEMPTS=0
     STATUS=99
 
     until [ $STATUS -eq 0 ]; do
-      pg_isready -d "${POSTGRESQL_DATABASE}" -h "${POSTGRESQL_HOST}" -U "${POSTGRESQL_USERNAME}" &>/dev/null
+      pg_isready -d "${DB_DATABASE}" -h "${DB_HOST}" -U "${DB_USER}" &>/dev/null
       STATUS=$?
 
       if [ $ATTEMPTS -gt 500 ]; then


### PR DESCRIPTION
BREAKING CHANGE: This replaces the `POSTGRES_*` prefixes with `DB_*` since that is our standard naming convention in app land. I also set the `DB_URL` when `postgres.enabled=true`.