### PR TITLE
fix(golang): disable sslmode on the sidecar DB_URL

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.0.0
-appVersion: 4.0.0
+version: 4.0.1
+appVersion: 4.0.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
                   name: {{ .Release.Name }}-postgresql
                   key: postgresql-password
             - name: DB_URL
-              value: postgress://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):5432/$(DB_DATABASE)
+              value: postgress://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):5432/$(DB_DATABASE)?sslmode=disable
             {{- end }}
             {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}


### PR DESCRIPTION
Disables the sslmode for the DB_URL envvar we inject. See: https://onenr.io/0znQx0GDJQV