### PR TITLE
fix: fix ports in golang chart's probes

### DIFF
--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: health
+              port: {{ .Values.livenessProbe.port }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -176,7 +176,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: health
+              port: {{ .Values.readinessProbe.port }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -83,6 +83,7 @@ podLabels: {}
 ##
 livenessProbe:
   enabled: true
+  port: 8080
   path: '/'
   initialDelaySeconds: 60
   periodSeconds: 10
@@ -92,6 +93,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
+  port: 8080
   path: '/'
   initialDelaySeconds: 10
   periodSeconds: 5


### PR DESCRIPTION
These need to be integers.

Relevant error:
```
Warning  Unhealthy  3m41s (x3 over 4m1s)  kubelet, gke-apps-stage-default-node-pool-d6a129c0-303a  Liveness probe errored: strconv.Atoi: parsing "health": invalid syntax                                    ││   Warning  Unhealthy  7s (x58 over 4m52s)   kubelet, gke-apps-stage-default-node-pool-d6a129c0-303a  Readiness probe errored: strconv.Atoi: parsing "health": invalid syntax  
```