### PR TITLE
fix: revert "fix ports in golang chart's probes"

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.0.3
-appVersion: 4.0.3
+version: 4.0.2
+appVersion: 4.0.2
 type: application
 keywords:
   - go

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.0.2
-appVersion: 4.0.2
+version: 4.0.4
+appVersion: 4.0.4
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: {{ .Values.livenessProbe.port }}
+              port: health
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -176,7 +176,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: {{ .Values.readinessProbe.port }}
+              port: health
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -83,7 +83,6 @@ podLabels: {}
 ##
 livenessProbe:
   enabled: true
-  port: 8080
   path: '/'
   initialDelaySeconds: 60
   periodSeconds: 10
@@ -93,7 +92,6 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  port: 8080
   path: '/'
   initialDelaySeconds: 10
   periodSeconds: 5


### PR DESCRIPTION
Reverts fluidtruck/helm-charts#27