### PR TITLE
fix: misplaced swagger host in TLS block

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.1.0
-appVersion: 4.1.0
+version: 4.1.1
+appVersion: 4.1.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -66,15 +66,15 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
+      {{- if .Values.swagger.enabled }}
+      - {{ tpl .Values.swagger.ingress.hostname . | quote }}
+      {{- end }}
       {{- if .Values.ingress.hostname }}
       - {{ tpl .Values.ingress.hostname . | quote }}
       secretName: {{ printf "%s-tls" .Release.Namespace | replace "." "-" }}
       {{- else }}
       - {{ printf "*.%s" (include "golang.ingressRootHostname" .) | quote }}
       secretName: {{ printf "%s-wildcard-tls" .Release.Namespace | replace "." "-" }}
-      {{- end }}
-      {{- if .Values.swagger.enabled }}
-      - {{ tpl .Values.swagger.ingress.hostname . | quote }}
       {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The chart would fail to render properly since as-is it was just throwing
in a random list entry at the end of the TLS block :facepalm:

`helm template` with relevant values:
```
  tls:
    - hosts:
      - "golang-swagger.local"
      - "delivery.stage.fluidtruck.io"
      secretName: default-tls
```