### PR TITLE
feat: add Service Account annotations

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.1.1
-appVersion: 4.1.1
+version: 4.2.0
+appVersion: 4.2.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "common.names.fullname" . }}
+  {{- if .Values.serviceAccountAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccountAnnotations "context" $) | nindent 4 }}
+  {{- end }}

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -2,7 +2,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "common.names.fullname" . }}
-  {{- if .Values.serviceAccountAnnotations }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccountAnnotations .Values.commonAnnotations }}
   annotations:
+    {{- if .Values.serviceAccountAnnotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccountAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -78,6 +78,13 @@ podAnnotations: {}
 ##
 podLabels: {}
 
+## Additional k8s Service Account annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+## For example, to add a Workload identity binding
+serviceAccountAnnotations: {}
+  # iam.gke.io/gcp-service-account: example-sa@applications-stage-2535.iam.gserviceaccount.com
+
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ##


### PR DESCRIPTION
In order to enable Workload Identity binding to GCP service accounts, we
need to expose adding custom annotations to the service account we
create for Vault reasons

[Relevant GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)