### PR TITLE
feat(golang): use docs path

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.2.0
-appVersion: 4.2.0
+version: 4.3.0
+appVersion: 4.3.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-swagger-values.yaml
+++ b/charts/golang/ci/with-swagger-values.yaml
@@ -1,3 +1,6 @@
+ingress:
+  enabled: true
+
 swagger:
   enabled: true
   image:

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -33,6 +33,13 @@ spec:
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+          {{- if .Values.swagger.enabled }}
+          - path: /docs
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
+          {{- end }}
     {{- else }}
     - host: {{ include "golang.ingressHostname" . | quote }}
       http:
@@ -42,33 +49,17 @@ spec:
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
-    {{- end }}
-    {{- if .Values.swagger.enabled }}
-    - host: {{ tpl .Values.swagger.ingress.hostname . | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
+          {{- if .Values.swagger.enabled }}
+          - path: /docs
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
-    {{- end }}
-    {{- range .Values.ingress.extraHosts }}
-    - host: {{ tpl .name $ | quote }}
-      http:
-        paths:
-          - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
+          {{- end }}
     {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      {{- if .Values.swagger.enabled }}
-      - {{ tpl .Values.swagger.ingress.hostname . | quote }}
-      {{- end }}
       {{- if .Values.ingress.hostname }}
       - {{ tpl .Values.ingress.hostname . | quote }}
       secretName: {{ printf "%s-tls" .Release.Namespace | replace "." "-" }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -354,12 +354,6 @@ swagger:
   ##
   port: 8081
 
-  ## Ingress
-  ##
-  ingress:
-    hostname: golang-swagger.local
-    annotations: {}
-
   ## Image
   ##
   # image:


### PR DESCRIPTION
This swaps Swagger to use the `/docs` path for services. This should resolve the TLS issues we're seeing with the wildcard certs and normal certs being in the same namespace.