### PR TITLE
feat(golang): simplify tls generation

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 4.3.0
-appVersion: 4.3.0
+version: 5.0.0
+appVersion: 5.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-ingress-and-devMode.yaml
+++ b/charts/golang/ci/with-ingress-and-devMode.yaml
@@ -1,6 +1,6 @@
 ingress:
   enabled: true
-  domain: test.local
+  devMode: true
   tls:
     enabled: true
     issuer: "testing"

--- a/charts/golang/ci/with-ingress-values.yaml
+++ b/charts/golang/ci/with-ingress-values.yaml
@@ -1,6 +1,6 @@
 ingress:
   enabled: true
-  hostname: "{{ .Release.Name }}.local"
+  domain: stage.fluidtruck.io
   tls:
     enabled: true
     issuer: "testing"

--- a/charts/golang/ci/with-swagger-values.yaml
+++ b/charts/golang/ci/with-swagger-values.yaml
@@ -1,5 +1,8 @@
 ingress:
   enabled: true
+  tls:
+    enabled: true
+    issuer: "testing"
 
 swagger:
   enabled: true

--- a/charts/golang/templates/NOTES.txt
+++ b/charts/golang/templates/NOTES.txt
@@ -1,20 +1,17 @@
 {{- if .Values.ingress.enabled }}
 {{- $protocol := ternary "https" "http" .Values.ingress.tls.enabled }}
-To access your application using your browser, open the following URL(s):
-{{ if .Values.ingress.hostname }}
-  {{ $protocol }}://{{ tpl .Values.ingress.hostname . }}
-{{- else }}
+To access your application using your browser, open the following URL(s)
+
   {{ $protocol }}://{{ include "golang.ingressHostname" . }}
-{{- end }}
 
 {{- end }}
 
 To access your application using kubectl port forwarding, use the following command:
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 8090:{{ .Values.service.port }}
 
 Then access your application using your browser, open the following URL:
 
-  http://127.0.0.1:8080
+  http://127.0.0.1:8090
 
 {{- include "golang.validateValues" . }}

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -70,19 +70,23 @@ Usage:
 {{- end -}}
 
 {{/*
-Print root hostname to be used other place.
+Print root hostname to be used for the ingress and TLS certificate.
 Usage:
 {{ include "golang.ingressRootHostname" . }}
 */}}
 {{- define "golang.ingressRootHostname" -}}
-{{- printf "%s.%s" .Release.Namespace .Values.ingress.domain -}}
+{{- .Values.ingress.domain -}}
 {{- end -}}
 
 {{/*
-Print hostname for the ingress.
+Print FQDN hostname to be used for the ingress.
 Usage:
 {{ include "golang.ingressHostname" . }}
 */}}
 {{- define "golang.ingressHostname" -}}
+{{- if .Values.ingress.devMode -}}
 {{- printf "%s.%s" .Release.Name (include "golang.ingressRootHostname" .) -}}
+{{- else -}}
+{{- include "golang.ingressRootHostname" . -}}
+{{- end }}
 {{- end -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -117,10 +117,10 @@ spec:
           {{- end }}
           env:
             - name: PORT
-              value: {{ .Values.swagger.port | quote }}
+              value: "8081"
           ports:
             - name: swagger
-              containerPort: {{ .Values.swagger.port }}
+              containerPort: 8081
         {{- end }}
         - name: app
           image: {{ template "golang.image" . }}

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -24,23 +24,6 @@ metadata:
   {{- end }}
 spec:
   rules:
-    {{- if .Values.ingress.hostname }}
-    - host: {{ tpl .Values.ingress.hostname . | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
-          {{- if .Values.swagger.enabled }}
-          - path: /docs
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
-          {{- end }}
-    {{- else }}
     - host: {{ include "golang.ingressHostname" . | quote }}
       http:
         paths:
@@ -52,20 +35,20 @@ spec:
           {{- if .Values.swagger.enabled }}
           - path: /docs
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.ingress.pathType }}
+            pathType: Prefix
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
+          - path: /swagger.json
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: Exact
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
           {{- end }}
-    {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      {{- if .Values.ingress.hostname }}
-      - {{ tpl .Values.ingress.hostname . | quote }}
-      secretName: {{ printf "%s-tls" .Release.Namespace | replace "." "-" }}
-      {{- else }}
+      - {{ include "golang.ingressRootHostname" . | quote }}
       - {{ printf "*.%s" (include "golang.ingressRootHostname" .) | quote }}
-      secretName: {{ printf "%s-wildcard-tls" .Release.Namespace | replace "." "-" }}
-      {{- end }}
+      secretName: {{ printf "%s-tls" .Release.Namespace | replace "." "-" }}
   {{- end }}
 {{- end }}

--- a/charts/golang/templates/service.yaml
+++ b/charts/golang/templates/service.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
     {{- if .Values.swagger.enabled }}
     - name: swagger
-      port: {{ .Values.swagger.port }}
+      port: 8081
       targetPort: swagger
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -24,11 +24,11 @@ image:
 ##
 kubeVersion:
 
-## String to partially override node.fullname template (will maintain the release name)
+## String to partially override golang.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override node.fullname template
+## String to fully override golang.fullname template
 ##
 # fullnameOverride:
 
@@ -42,7 +42,7 @@ applicationPort: 8090
 
 ## Enables extra ports for the container
 ##
-extraApplicationPorts: []
+extraApplicationPorts: {}
 #   delve: 2345
 
 ## Affinity for pod assignment. Evaluated as a template.
@@ -255,26 +255,36 @@ ingress:
   ##
   enabled: false
 
+  ## Enable to prepend the .Release.Name as a subdomain.
+  ##
+  devMode: false
+
   ## Set this to the required desired IngressClass. Set to false to use your cluster's default ingress.
   ##
   class: nginx
 
-  ## Set this to a specific hostname, and the automatic hostname creations will be skipped.
-  ##
-  # hostname: my-app.fluiddev.io
-
   ## Set this to the domain you want to use.
   ##
-  domain: fluiddev.io
+  domain: fluidtruck.io
 
-  ## The Path to Node.js. You may need to set this to '/*' in order to use this
-  ## with ALB ingress controllers.
+  ## The root path. You may need to set this to '/*' in order to use this with ALB ingress
+  ## controllers.
   ##
   path: /
 
   ## Ingress Path type
   ##
   pathType: ImplementationSpecific
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  # apiVersion:
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  annotations: {}
 
   ## Configure TLS
   ##
@@ -286,16 +296,6 @@ ingress:
     ## Set this to true in order to add the corresponding annotations for cert-manager
     ##
     issuer: "letsencrypt-staging"
-
-  ## Override API Version (automatically detected if not set)
-  ##
-  # apiVersion:
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  annotations: {}
 
 ## Configure the hpa resource that enables autoscaling of the deployment
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -349,10 +349,6 @@ swagger:
   ## Set to true to enable Swagger
   ##
   enabled: false
-
-  ## Port
-  ##
-  port: 8081
 
   ## Image
   ##


### PR DESCRIPTION
As I was working through Swagger, I also discovered our TLS was going to have major issues once we go back to a single domain. With this approach, we will generate a _single_ certificate per service and it will handle the PRs + Static hosts, and is easier to configure on the dev side. For example:

**dev/stage:**
```yaml
ingress:
  enabled: true
  tls:
    enabled: true
    issuer: "letsencrypt-production"

swagger:
  enabled: true
```

Then using the following, you can install the chart:

```sh
# for pull requests, results in my-feature.api-platform.stage.fluidtruck.io
helm upgrade ${RELEASE_NAME} ./charts/golang \
    --install \
    --namespace backend \
    --create-namespace \
    --set ingress.devMode="true" \
    --set ingress.domain="${{ matrix.service }}.stage.fluidtruck.io" \
   # ... everything else

# for stage, results in api-platform.stage.fluidtruck.io
helm upgrade api-platform ./charts/golang \
    --install \
    --namespace backend \
    --create-namespace \
    --set ingress.domain="${{ matrix.service }}.stage.fluidtruck.io" \
   # ... everything else
```