### PR TITLE
feat(golang): add serviceAccount config

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 5.0.1
-appVersion: 5.0.1
+version: 5.1.0
+appVersion: 5.1.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-sa-values.yaml
+++ b/charts/golang/ci/with-sa-values.yaml
@@ -1,0 +1,3 @@
+serviceAccount:
+  create: true
+  name: "foo-bar"

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -6,6 +6,17 @@ Return the proper image name
 {{- end -}}
 
 {{/*
+Return the service account name
+*/}}
+{{- define "golang.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+  {{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+  {{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "golang.imagePullSecrets" -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "common.names.fullname" . }}
+      serviceAccountName: {{ template "golang.serviceAccountName" . }}
       {{- if or (eq "true" (include "golang.waitForRedis" .)) (eq "true" (include "golang.waitForPostgresql" .)) }}
       initContainers:
         {{- if eq "true" (include "golang.waitForRedis" .) }}

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -1,17 +1,19 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "golang.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.serviceAccountAnnotations .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
-    {{- if .Values.serviceAccountAnnotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccountAnnotations "context" $) | nindent 4 }}
-    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -78,13 +78,6 @@ podAnnotations: {}
 ##
 podLabels: {}
 
-## Additional k8s Service Account annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-## For example, to add a Workload identity binding
-serviceAccountAnnotations: {}
-  # iam.gke.io/gcp-service-account: example-sa@apps-stage-150c.iam.gserviceaccount.com
-
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ##
@@ -342,6 +335,22 @@ redis:
   architecture: standalone
   auth:
     password: redis
+
+## Configure the service account
+##
+serviceAccount:
+  create: false
+
+  ## Define a custom service account name
+  ##
+  name: ""
+
+  ## Additional k8s Service Account annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  ## For example, to add a Workload identity binding
+  annotations: {}
+    # iam.gke.io/gcp-service-account: example-sa@apps-stage-150c.iam.gserviceaccount.com
 
 ## Swagger Configuration
 ##


### PR DESCRIPTION
This adds the ability to create a service account. If disabled, we will use the `default`. This allows our default SA for a tenant to have basic workload identity permissions.