### PR TITLE
fix(cronjob): trunc cronjob name to 52 chars

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1
 type: application
 keywords:
   - cronjob

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" $top }}
 kind: CronJob
 metadata:
-  name: {{ printf "%s-%s" (include "common.names.fullname" $top) .name | trunc 253 | trimSuffix "-" | quote }}
+  name: {{ printf "%s-%s" (include "common.names.fullname" $top) .name | trunc 52 | trimSuffix "-" | quote }}
   labels: {{- include "common.labels.standard" $top | nindent 4 }}
     cronjob: {{ .name | quote }}
     {{- if $top.Values.commonLabels }}


### PR DESCRIPTION
Names need to be 52 chars or less.

```
Error: release reservation-section-cronjob failed, and has been uninstalled due to atomic being set: CronJob.batch "reservation-section-cronjob-reservation-section-cronjob" is invalid: metadata.name: Invalid value: "reservation-section-cronjob-reservation-section-cronjob": must be no more than 52 characters
```