### PR TITLE
feat(golang): add readiness and liveness probe port

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 5.2.0
-appVersion: 5.2.0
+version: 5.3.0
+appVersion: 5.3.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -189,7 +189,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: health
+              port: {{ .Values.livenessProbe.port | default "health" }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -200,7 +200,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: health
+              port: {{ .Values.readinessProbe.port | default "health" }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -97,6 +97,7 @@ podLabels: {}
 livenessProbe:
   enabled: true
   path: '/'
+  # port: 8090
   initialDelaySeconds: 60
   periodSeconds: 10
   timeoutSeconds: 5
@@ -106,6 +107,7 @@ livenessProbe:
 readinessProbe:
   enabled: true
   path: '/'
+  # port: 8090
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 3


### PR DESCRIPTION
Allow the devs to override readiness and liveness probe ports. This is helpful for fluidshare/plasma's scheduler service.