### PR TITLE
feat: Add optional k8s SA to CronJob chart

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 1.1.1
-appVersion: 1.1.1
+version: 1.2.0
+appVersion: 1.2.0
 type: application
 keywords:
   - cronjob

--- a/charts/cronjob/templates/_helpers.tpl
+++ b/charts/cronjob/templates/_helpers.tpl
@@ -6,6 +6,17 @@ Return the proper NextJS image name
 {{- end -}}
 
 {{/*
+Return the service account name
+*/}}
+{{- define "cronjob.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+  {{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+  {{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "cronjob.imagePullSecrets" -}}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             cronjob: {{ .name | quote }}
         spec:
           restartPolicy: OnFailure
-          serviceAccountName: {{ template "cronjob.serviceAccountName" . }}
+          serviceAccountName: {{ template "cronjob.serviceAccountName" $top }}
           {{- if $top.Values.containerSecurityContext.enabled }}
           securityContext: {{- omit $top.Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -25,6 +25,7 @@ spec:
             cronjob: {{ .name | quote }}
         spec:
           restartPolicy: OnFailure
+          serviceAccountName: {{ template "cronjob.serviceAccountName" . }}
           {{- if $top.Values.containerSecurityContext.enabled }}
           securityContext: {{- omit $top.Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/cronjob/templates/sa.yaml
+++ b/charts/cronjob/templates/sa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cronjob.serviceAccountName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -121,6 +121,22 @@ cronjobs:
     successfulJobsHistoryLimit: 0
     failedJobsHistoryLimit: 0
 
+## Configure the service account
+##
+serviceAccount:
+  create: false
+
+  ## Define a custom service account name
+  ##
+  name: ""
+
+  ## Additional k8s Service Account annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  ## For example, to add a Workload identity binding
+  annotations: {}
+    # iam.gke.io/gcp-service-account: example-sa@apps-stage-150c.iam.gserviceaccount.com
+
 ## Configure the postgresql service
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ##


### PR DESCRIPTION
Adds an optional service account creation to CronJob helm chart. This is
necessary to use Workload Identity to bind GCP credentials for a CronJob
to access.