### PR TITLE
feat(golang): add labels

### DIFF
--- a/charts/golang/Chart.lock
+++ b/charts/golang/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://fluidtruck.github.io/helm-charts
-  version: 1.1.0
+  version: 1.2.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.10.1
+  version: 11.1.28
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.3.2
-digest: sha256:db0576ec1b8e9e069388f9ff4b28009e9745739ceb8f62fa4435eb64385590f0
-generated: "2021-09-22T09:38:25.498242-06:00"
+  version: 15.7.6
+digest: sha256:23963c812f8f412c1849fddc35b58c19f1dbe69df2d6467e4b04f7cc21fac5e9
+generated: "2022-07-06T14:08:29.603779-04:00"

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 5.3.0
-appVersion: 5.3.0
+version: 5.4.0
+appVersion: 5.4.0
 type: application
 keywords:
   - go
@@ -20,11 +20,11 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
-    version: "10.10.1"
+    version: "11.1.28"
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     tags:
       - redis
-    version: "15.3.2"
+    version: "15.7.6"
     condition: redis.enabled

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 5.4.0
-appVersion: 5.4.0
+version: 6.0.0
+appVersion: 6.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/_helpers.tpl
+++ b/charts/golang/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Usage:
 {{ include "golang.waitForPostgresql" . }}
 */}}
 {{- define "golang.waitForPostgresql" -}}
-{{- if and (eq .Values.postgresql.enabled true) (eq .Values.postgresql.wait true) (.Values.postgresql.postgresqlPassword) -}}
+{{- if and (eq .Values.postgresql.enabled true) (eq .Values.postgresql.wait true) (.Values.postgresql.auth.password) -}}
 {{- print "true" -}}
 {{- else -}}
 {{- print "false" -}}

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -7,10 +7,19 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.github.enabled }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
@@ -25,7 +34,10 @@ spec:
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
         {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.github.enabled }}
+        {{- include "common.annotations.github" . | nindent 8 }}
         {{- end }}
         {{- if .Values.vault.enabled }}
         vault.hashicorp.com/role: {{ tpl .Values.vault.role . | quote }}
@@ -40,18 +52,24 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.fluidtruck.enabled }}
+        {{- include "common.labels.fluidtruck" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.github.enabled }}
+        {{- include "common.labels.github" . | nindent 8 }}
         {{- end }}
     spec:
       {{- include "golang.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $ ) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $ ) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" ( dict "value" .Values.tolerations "context" $ ) | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -91,9 +109,9 @@ spec:
             - name: DB_HOST
               value: {{ $dbHost }}
             - name: DB_DATABASE
-              value: {{ .Values.postgresql.postgresqlDatabase }}
+              value: {{ .Values.postgresql.auth.database }}
             - name: DB_USER
-              value: {{ .Values.postgresql.postgresqlUsername }}
+              value: {{ .Values.postgresql.auth.username }}
           args:
             - /mnt/postgresql/wait-for-postgresql.sh
           volumeMounts:
@@ -105,7 +123,7 @@ spec:
         {{- if .Values.swagger.enabled }}
         - name: swagger
           {{- if .Values.swagger.image }}
-          image: {{ include "common.images.image" (dict "imageRoot" .Values.swagger.image) }}
+          image: {{ include "common.images.image" ( dict "imageRoot" .Values.swagger.image ) }}
           imagePullPolicy: {{ .Values.swagger.image.pullPolicy | quote }}
           {{- else }}
           image: {{ template "golang.image" . }}
@@ -143,34 +161,34 @@ spec:
             {{- if .Values.postgresql.enabled }}
             - name: DB_HOST
               value: {{ $dbHost }}
-            - name: DB_USER
-              value: {{ .Values.postgresql.postgresqlUsername }}
             - name: DB_DATABASE
-              value: {{ .Values.postgresql.postgresqlDatabase }}
+              value: {{ .Values.postgresql.auth.database }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.auth.username }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-postgresql
-                  key: postgresql-password
+                  key: password
             - name: DB_URL
               value: postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):5432/$(DB_DATABASE)?sslmode=disable
             {{- end }}
             {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}
               {{- if or (typeIs "string" $value) (typeIs "float64" $value) (typeIs "bool" $value) }}
-              value: {{ include "common.tplvalues.render" (dict "value" $value "context" $) | quote }}
+              value: {{ include "common.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
               {{- else }}
-              {{- include "common.tplvalues.render" (dict "value" $value "context" $) | nindent 14 }}
+              {{- include "common.tplvalues.render" ( dict "value" $value "context" $ ) | nindent 14 }}
               {{- end }}
             {{- end }}
           envFrom:
             {{- if .Values.envVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsCM "context" $) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.envVarsCM "context" $ ) }}
             {{- end }}
             {{- if .Values.envVarsSecret }}
             - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsSecret "context" $) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.envVarsSecret "context" $ ) }}
             {{- end }}
           ports:
             - name: http
@@ -208,7 +226,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.lifecycle }}
-          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycle "context" $) | nindent 12 }}
+          lifecycle: {{- include "common.tplvalues.render" ( dict "value" .Values.lifecycle "context" $ ) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/golang/templates/hpa.yaml
+++ b/charts/golang/templates/hpa.yaml
@@ -7,13 +7,22 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.hpa.annotations .Values.commonAnnotations }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.hpa.annotations .Values.commonAnnotations .Values.github.enabled }}
   annotations:
     {{- if .Values.hpa.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.hpa.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.hpa.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/charts/golang/templates/ingress.yaml
+++ b/charts/golang/templates/ingress.yaml
@@ -7,7 +7,13 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.ingress.tls.enabled .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.tls.enabled .Values.ingress.annotations .Values.commonAnnotations .Values.github.enabled }}
   annotations:
     {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.issuer }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.issuer | quote }}
@@ -16,10 +22,13 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
@@ -31,18 +40,18 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" ( dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $ )  | nindent 14 }}
           {{- if .Values.swagger.enabled }}
           - path: /docs
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: Prefix
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" ( dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $ )  | nindent 14 }}
           - path: /swagger.json
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: Exact
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" ( dict "serviceName" (include "common.names.fullname" .) "servicePort" "swagger" "context" $ )  | nindent 14 }}
           {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:

--- a/charts/golang/templates/postgresql/wait-for-postgresql.yaml
+++ b/charts/golang/templates/postgresql/wait-for-postgresql.yaml
@@ -7,6 +7,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
 data:
   wait-for-postgresql.sh: |
     #/bin/sh

--- a/charts/golang/templates/redis/wait-for-redis.yaml
+++ b/charts/golang/templates/redis/wait-for-redis.yaml
@@ -7,6 +7,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
 data:
   wait-for-redis.sh: |
     #/bin/sh

--- a/charts/golang/templates/sa.yaml
+++ b/charts/golang/templates/sa.yaml
@@ -7,13 +7,22 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations  .Values.github.enabled }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/golang/templates/service.yaml
+++ b/charts/golang/templates/service.yaml
@@ -6,13 +6,22 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations .Values.github.enabled }}
   annotations:
     {{- if .Values.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -335,11 +335,12 @@ hpa:
 postgresql:
   enabled: false
   wait: false
-  postgresqlUsername: postgresql
-  postgresqlPassword: postgresql
-  postgresqlDatabase: postgresql
+  auth:
+    username: postgres
+    password: postgres
+    database: postgres
   image:
-    tag: '13.4.0'
+    tag: '14.2.0'
 
 ## Configure the redis service
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
@@ -382,3 +383,16 @@ swagger:
   #   tag: "v0.27.0"
   #   # pullSecrets:
   #   #   - myRegistryKeySecretName
+
+## FluidTruck labels
+##
+fluidtruck:
+  enabled: false
+
+## GitHub labels and annotations
+##
+github:
+  enabled: false
+  repo: {}
+  pr: {}
+  release: {}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -336,9 +336,9 @@ postgresql:
   enabled: false
   wait: false
   auth:
-    username: postgres
-    password: postgres
-    database: postgres
+    username: postgresql
+    password: postgresql
+    database: postgresql
   image:
     tag: '14.2.0'
 


### PR DESCRIPTION
As per https://fluidtruck.atlassian.net/browse/DO-154.

Add K8S and GitHub labels to objects. This should allow filtering/identification as much in K8S as in NewRelic.

Labels:

* fluidtruck.io/app
* fluidtruck.io/env
* fluidtruck.io/team
* github.com/branch
* github.com/pull-request
* github.com/repository
* github.com/release

Annotations:

* github.com/repository-url
* github.com/pull-request-url
* github.com/pull-request-owner
* github.com/release-url

---
PostgreSQL:

* Upgrade postgresql chart version, previous version no longer available
  * Chart version 11.1.28 = PostgreSQL 14.2, which is what we've starting going to in stage/prod
  * Going to PostgreSQL 14.x introduces some changes, as noted here - https://github.com/bitnami/charts/issues/8900#issuecomment-1029710668
  * Auth-related helm values have also changed for username/password/etc.

* Create a new database, a non-admin username and assign a password to that username (this is different from the previous behaviour that created an admin username)

Redis:

* Upgrade redis chart version, previous version no longer available
  * Chart version 15.7.6 = Redis 6.2.6
  * Going to chart version 16.x seems to imply potential changes - https://github.com/bitnami/charts/tree/master/bitnami/redis/#to-1600