### PR TITLE
feat(golang): allow arrays for envVarsCM and envVarsSecret

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 6.1.0
-appVersion: 6.1.0
+version: 6.2.0
+appVersion: 6.2.0
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -161,6 +161,8 @@ spec:
             {{- if .Values.postgresql.enabled }}
             - name: DB_HOST
               value: {{ $dbHost }}
+            - name: DB_HOST_READ
+              value: {{ $dbHost}}
             - name: DB_DATABASE
               value: {{ .Values.postgresql.auth.database }}
             - name: DB_USER
@@ -183,13 +185,28 @@ spec:
             {{- end }}
           envFrom:
             {{- if .Values.envVarsCM }}
+            {{- if kindIs "string" .Values.envVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.envVarsCM "context" $ ) }}
+            {{- else }}
+            {{- range $value := .Values.envVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" $value "context" $ ) }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.envVarsSecret }}
+            {{- if kindIs "string" .Values.envVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.envVarsSecret "context" $ ) }}
+            {{- else }}
+            {{- range $value := .Values.envVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" $value "context" $ ) }}
             {{- end }}
+            {{- end }}
+            {{- end }}
+
           ports:
             - name: http
               containerPort: {{ .Values.applicationPort }}


### PR DESCRIPTION
This will allow us to add arrays for secrets and configmaps. This is helpful for microservices that have a `dotenv` and `db-creds` secret. We can now do this:

```
envVarsSecret:
  - db-creds
  - dotenv
```