### PR TITLE
fix: fix github labels and annotations

### DIFF
--- a/charts/common/templates/_annotations.tpl
+++ b/charts/common/templates/_annotations.tpl
@@ -7,6 +7,7 @@ github.com/repository-url: {{ .Values.github.repo.url }}
 {{ if .Values.github.pr.number }}
 github.com/pull-request-url: {{ .Values.github.pr.url }}
 github.com/pull-request-owner: {{ .Values.github.pr.owner }}
+github.com/pull-request-branch: {{ .Values.github.pr.branch }}
 {{ else if .Values.github.release.url }}
 github.com/release-url: {{ .Values.github.release.url }}
 {{- end -}}

--- a/charts/common/templates/_labels.tpl
+++ b/charts/common/templates/_labels.tpl
@@ -24,10 +24,9 @@ Kubernetes GitHub labels
 {{- define "common.labels.github" -}}
 github.com/repository: {{ .Values.github.repo.name }}
 {{ if .Values.github.pr.number }}
-github.com/branch: {{ .Values.github.pr.branch }}
-github.com/pull-request: {{ .Values.github.pr.number }}
+github.com/pull-request: {{ .Values.github.pr.number | toString | quote }}
 {{ else if .Values.github.release.version }}
-github.com/release: {{ .Values.github.release.version }}
+github.com/release: {{ .Values.github.release.version | toString | quote }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
* The / character is invalid in a label.  Moving branch name to annotations.
* The PR number needs to be a string and quotes, as labels needs to be strings and not integers.