### PR TITLE
fix(cronjob): use $top

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 2.0.0
-appVersion: 2.0.0
+version: 2.0.1
+appVersion: 2.0.1
 type: application
 keywords:
   - cronjob

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -12,10 +12,10 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $top.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if $top.Values.fluidtruck.enabled }}
-    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- (include "common.labels.fluidtruck" $top) | nindent 4 }}
     {{- end }}
     {{- if $top.Values.github.enabled }}
-    {{- include "common.labels.github" . | nindent 4 }}
+    {{- (include "common.labels.github" $top) | nindent 4 }}
     {{- end }}
   {{- if or $top.Values.commonAnnotations $top.Values.github.enabled }}
   annotations:
@@ -23,7 +23,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $top.Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if $top.Values.github.enabled }}
-    {{- include "common.annotations.github" $top | nindent 4 }}
+    {{- (include "common.annotations.github" $top) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
Need to use `$top` to prevent this error:

```shell
Error: template: cronjob/templates/cronjob.yaml:15:8: executing "cronjob/templates/cronjob.yaml" at <include "common.labels.fluidtruck" .>: error calling include: template: cronjob/charts/common/templates/_labels.tpl:16:29: executing "common.labels.fluidtruck" at <.Values.fluidtruck.app>: nil pointer evaluating interface ***.fluidtruck
```