### PR TITLE
fix(golang,cronjob): add export to shared and env

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.0.3
+appVersion: 2.0.3
 type: application
 keywords:
   - cronjob

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -66,14 +66,14 @@ spec:
             {{ printf "vault.hashicorp.com/agent-inject-template-.env.shared: |" }}
               {{ printf "{{- with secret \"kv/data/%s/%s/shared\" -}}" $top.Values.vault.auth.department $top.Values.vault.auth.team }}
               {{ printf "{{- range $k, $v := .Data.data -}}" }}
-              {{ printf "{{ $k }}=\"{{ $v }}\"" }}
+              {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
               {{ printf "{{ end -}}" }}
               {{ printf "{{- end -}}" }}
             vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s/%s/%s" $top.Values.vault.auth.department $top.Values.vault.auth.team $top.Values.fluidtruck.env | quote }}
             {{ printf "vault.hashicorp.com/agent-inject-template-.env: |" }}
               {{ printf "{{- with secret \"kv/data/%s/%s/%s\" -}}" $top.Values.vault.auth.department $top.Values.vault.auth.team $top.Values.fluidtruck.env }}
               {{ printf "{{- range $k, $v := .Data.data -}}" }}
-              {{ printf "{{ $k }}=\"{{ $v }}\"" }}
+              {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
               {{ printf "{{ end -}}" }}
               {{ printf "{{- end -}}" }}
             {{- range $top.Values.vault.secrets -}}

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 7.1.0
-appVersion: 7.1.0
+version: 7.1.1
+appVersion: 7.1.1
 type: application
 keywords:
   - go

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -57,14 +57,14 @@ spec:
         {{ printf "vault.hashicorp.com/agent-inject-template-.env.shared: |" }}
           {{ printf "{{- with secret \"kv/data/%s/%s/shared\" -}}" .Values.vault.auth.department .Values.vault.auth.team }}
           {{ printf "{{- range $k, $v := .Data.data -}}" }}
-          {{ printf "{{ $k }}=\"{{ $v }}\"" }}
+          {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
           {{ printf "{{ end -}}" }}
           {{ printf "{{- end -}}" }}
         vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s/%s/%s" .Values.vault.auth.department .Values.vault.auth.team .Values.fluidtruck.env | quote }}
         {{ printf "vault.hashicorp.com/agent-inject-template-.env: |" }}
           {{ printf "{{- with secret \"kv/data/%s/%s/%s\" -}}" .Values.vault.auth.department .Values.vault.auth.team .Values.fluidtruck.env }}
           {{ printf "{{- range $k, $v := .Data.data -}}" }}
-          {{ printf "{{ $k }}=\"{{ $v }}\"" }}
+          {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
           {{ printf "{{ end -}}" }}
           {{ printf "{{- end -}}" }}
         {{- range .Values.vault.secrets -}}


### PR DESCRIPTION
Missing `export` causes the `source` calls to these two files to not actually load the contents into the environment.