### PR TITLE
feat(golang)!: use an array for extraApplicationPorts

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 7.2.1
-appVersion: 7.2.1
+version: 8.0.0
+appVersion: 8.0.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-extra-application-ports-values.yaml.yaml
+++ b/charts/golang/ci/with-extra-application-ports-values.yaml.yaml
@@ -1,2 +1,3 @@
 extraApplicationPorts:
-  dlv: 2345
+  - name: delve
+    port: 2345

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -249,9 +249,9 @@ spec:
               containerPort: {{ .Values.applicationPort | int }}
             - name: health
               containerPort: {{ .Values.healthPort | int }}
-            {{- range $key, $value := .Values.extraApplicationPorts }}
-            - name: {{ $key }}
-              containerPort: {{ $value | int }}
+            {{- range .Values.extraApplicationPorts }}
+            - name: {{ .name | quote }}
+              containerPort: {{ .port | int }}
             {{- end }}
           {{- if .Values.extraVolumeMounts }}
           volumeMounts:

--- a/charts/golang/templates/service.yaml
+++ b/charts/golang/templates/service.yaml
@@ -39,23 +39,28 @@ spec:
   ports:
     - name: http-legacy
       port: 8090
+      appProtocol: grpc
       targetPort: http
     - name: http
       port: {{ .Values.service.port }}
+      appProtocol: {{ .Values.service.appProtocol }}
       targetPort: http
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort  }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-    {{- range $key, $value := .Values.extraApplicationPorts }}
-    - name: {{ $key }}
-      port: {{ $value | int }}
-      targetPort: {{ $key }}
-    {{- end }}
     {{- if .Values.swagger.enabled }}
     - name: swagger
       port: 8081
       targetPort: swagger
+    {{- end }}
+    {{- range .Values.extraApplicationPorts }}
+    - name: {{ .name | quote }}
+      port: {{ .port | int }}
+      targetPort: {{ .name | quote }}
+      {{- if .appProtocol }}
+      appProtocol: {{ .appProtocol | quote }}
+      {{- end }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -46,8 +46,10 @@ healthPort: 8080
 
 ## Enables extra ports for the container
 ##
-extraApplicationPorts: {}
-#   delve: 2345
+extraApplicationPorts: []
+#   - name: delve
+#     port: 2345
+#     appProtocol: http
 
 ## Additional volumes for app pod
 ##
@@ -229,6 +231,15 @@ service:
   ## HTTP Port
   ##
   port: 80
+
+  ## App Protocol
+  ##
+  ## - http
+  ## - grpc (Default)
+  ##
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+  ##
+  appProtocol: grpc
 
   ## clusterIP: ""
   ## loadBalancerIP for the Node Service (optional, cloud specific)


### PR DESCRIPTION
BREAKING CHANGE: `extraApplicationPorts` is now an array

---

While setting up Telepresence, I discovered that we need to leverage the [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) directive for gRPC services. Since our Golang chart is 99.99% for gRPC I defaulted to the `grpc` protocol. This was documented on the Telepresence community [here](https://datawire-oss.slack.com/archives/CAUBBJSQZ/p1666257430302089?thread_ts=1666099819.269849&cid=CAUBBJSQZ).

This can be set to `http` declaratively for services like go-demo and api-*.