### PR TITLE
fix: always set env

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 2.0.3
-appVersion: 2.0.3
+version: 2.0.4
+appVersion: 2.0.4
 type: application
 keywords:
   - cronjob

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -145,7 +145,6 @@ spec:
             {{- else }}
             command: {{- include "common.tplvalues.render" (dict "value" .command "context" $) | nindent 14 }}
             {{- end }}
-            {{- if or $top.Values.redis.enabled (gt (len $top.Values.envVars) 0) }}
             env:
               {{- if $top.Values.redis.enabled }}
               - name: REDIS_HOST
@@ -196,7 +195,6 @@ spec:
                 {{- include "common.tplvalues.render" (dict "value" $value "context" $) | nindent 14 }}
                 {{- end }}
               {{- end }}
-            {{- end }}
             {{- if or $top.Values.envVarsCM $top.Values.envVarsSecret }}
             envFrom:
               {{- if $top.Values.envVarsCM }}


### PR DESCRIPTION
Cronjob was not setting `env`, so `.Values.fluidtruck.*` was being ignored.