### PR TITLE
feat(golang): add pdb

### DIFF
--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 9.0.1
-appVersion: 9.0.1
+version: 9.1.0
+appVersion: 9.1.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-hpa-values.yaml
+++ b/charts/golang/ci/with-hpa-values.yaml
@@ -1,2 +1,4 @@
 hpa:
   enabled: true
+  minReplicas: 2
+  maxReplicas: 3

--- a/charts/golang/ci/with-pdb.yaml
+++ b/charts/golang/ci/with-pdb.yaml
@@ -1,0 +1,3 @@
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/charts/golang/templates/pdb.yaml
+++ b/charts/golang/templates/pdb.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.podDisruptionBudget.enabled  }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.fluidtruck.enabled }}
+    {{- include "common.labels.fluidtruck" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.labels.github" . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.github.enabled .Values.doppler.enabled }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.github.enabled }}
+    {{- include "common.annotations.github" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.doppler.enabled }}
+    secrets.doppler.com/reload: {{ .Values.doppler.reload | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -375,6 +375,14 @@ hpa:
   ##
   annotations: {}
 
+## Pod Disruption Budget
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+##
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
 ## Configure the postgresql service
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ##


### PR DESCRIPTION
This adds the Pod Disruption Budget configuration to Golang. This is recommended to use in the following two ways:

```yaml
replicaCount: 2

podDisruptionBudget:
  enabled: true
  minAvailable: 1

# or

hpa:
  enabled: true
  minReplicas: 2
  maxReplicas: 5

podDisruptionBudget:
  enabled: true
  minAvailable: 2
```

I wanted to enable automatic `minAvailable` defined by the value of `replicaCount` or `hpa.minReplicas`. However, the `mul` and `div` methods return `0`... Maybe we can improve this later. But for now, we'll just need to be declarative.

```yaml
minAvailable: {{ .Values.replicaCount | int | mul 0.5 | int }} # returns 0 for any odd value given to replicaCount
```