### PR TITLE
feat(cronjob,golang): add service to vault.auth

### DIFF
--- a/charts/cronjob/Chart.lock
+++ b/charts/cronjob/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://fluidtruck.github.io/helm-charts
-  version: 1.2.1
+  version: 1.3.0
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 11.1.28
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 15.7.6
-digest: sha256:49f719bac443393e22afc204baeb1b5b8df360d615e0da25b3335543184ab3e7
-generated: "2022-08-02T10:08:06.525601-06:00"
+digest: sha256:b08bc2d88e8d0412b24bd177732c12147865ad930526827ed439499ed10a4127
+generated: "2023-04-04T14:06:19.822561-06:00"

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: cronjob
 description: A chart for CronJobs.
 icon: https://contino.github.io/intro-k8/images/kubernetes/cronjob.png
-version: 2.0.4
-appVersion: 2.0.4
+version: 2.1.0
+appVersion: 2.1.0
 type: application
 keywords:
   - cronjob
 maintainers:
-  - name: ellisio
-    email: aellis@fluidtruck.com
+  - name: devops
+    email: devops@fluidtruck.com
 dependencies:
   - name: common
     repository: https://fluidtruck.github.io/helm-charts
@@ -17,13 +17,13 @@ dependencies:
       - fluidtruck-common
     version: 1.x.x
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - postgresql
     version: "11.1.28"
     condition: postgresql.enabled
   - name: redis
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - redis
     version: "15.7.6"

--- a/charts/cronjob/ci/with-vault-values.yaml
+++ b/charts/cronjob/ci/with-vault-values.yaml
@@ -1,3 +1,6 @@
+fluidtruck:
+  env: dev
+
 vault:
   enabled: true
   secrets:

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -54,7 +54,7 @@ spec:
             vault.hashicorp.com/auth-type: "gcp"
             vault.hashicorp.com/auth-config-type: "iam"
             vault.hashicorp.com/auth-config-service-account: {{ $top.Values.vault.auth.serviceAccount | quote }}
-            vault.hashicorp.com/role: {{ printf "%s-%s-%s" $top.Values.vault.auth.department $top.Values.vault.auth.team $top.Values.fluidtruck.env | quote }}
+            vault.hashicorp.com/role: {{ include "common.vault.role" ( dict "vault" $top.Values.vault "env" $top.Values.fluidtruck.env ) | quote }}
             vault.hashicorp.com/agent-inject-secret-newrelic: {{ printf "kv/data/%s/newrelic" $top.Values.vault.auth.department | quote }}
             {{ printf "vault.hashicorp.com/agent-inject-template-newrelic: |" }}
               {{ printf "{{- with secret \"kv/data/%s/newrelic\" -}}" $top.Values.vault.auth.department }}
@@ -62,16 +62,16 @@ spec:
               {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
               {{ printf "{{ end -}}" }}
               {{ printf "{{- end -}}" }}
-            vault.hashicorp.com/agent-inject-secret-.env.shared: {{ printf "kv/data/%s/%s/shared" $top.Values.vault.auth.department $top.Values.vault.auth.team | quote }}
+            vault.hashicorp.com/agent-inject-secret-.env.shared: {{ printf "kv/data/%s" ( include "common.vault.path" ( dict "vault" $top.Values.vault "name" "shared" ) ) | quote }}
             {{ printf "vault.hashicorp.com/agent-inject-template-.env.shared: |" }}
-              {{ printf "{{- with secret \"kv/data/%s/%s/shared\" -}}" $top.Values.vault.auth.department $top.Values.vault.auth.team }}
+              {{ printf "{{- with secret \"kv/data/%s\" -}}" ( include "common.vault.path" ( dict "vault" $top.Values.vault "name" "shared" ) ) }}
               {{ printf "{{- range $k, $v := .Data.data -}}" }}
               {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
               {{ printf "{{ end -}}" }}
               {{ printf "{{- end -}}" }}
-            vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s/%s/%s" $top.Values.vault.auth.department $top.Values.vault.auth.team $top.Values.fluidtruck.env | quote }}
+            vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s" ( include "common.vault.path" ( dict "vault" $top.Values.vault "name" $top.Values.fluidtruck.env ) ) | quote }}
             {{ printf "vault.hashicorp.com/agent-inject-template-.env: |" }}
-              {{ printf "{{- with secret \"kv/data/%s/%s/%s\" -}}" $top.Values.vault.auth.department $top.Values.vault.auth.team $top.Values.fluidtruck.env }}
+              {{ printf "{{- with secret \"kv/data/%s\" -}}" ( include "common.vault.path" ( dict "vault" $top.Values.vault "name" $top.Values.fluidtruck.env ) ) }}
               {{ printf "{{- range $k, $v := .Data.data -}}" }}
               {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
               {{ printf "{{ end -}}" }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -129,6 +129,7 @@ vault:
   auth:
     department: engineering
     team: devops
+    service: ''
     serviceAccount: soma-sa@project.iam.gserviceaccount.com
   secrets: []
     # The below example will use a standardized template

--- a/charts/golang/Chart.lock
+++ b/charts/golang/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://fluidtruck.github.io/helm-charts
-  version: 1.2.2
+  version: 1.3.0
 - name: postgresql
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 11.1.28
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 15.7.6
-digest: sha256:79c2236ecb9e45751c148bcbf8a5f911a4fe1997431395ec5d9397840c225337
-generated: "2023-01-20T19:13:42.510153-05:00"
+digest: sha256:b08bc2d88e8d0412b24bd177732c12147865ad930526827ed439499ed10a4127
+generated: "2023-04-04T14:17:31.447961-06:00"

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 9.1.0
-appVersion: 9.1.0
+version: 9.2.0
+appVersion: 9.2.0
 type: application
 keywords:
   - go

--- a/charts/golang/ci/with-vault-values.yaml
+++ b/charts/golang/ci/with-vault-values.yaml
@@ -1,3 +1,6 @@
+fluidtruck:
+  env: dev
+
 vault:
   enabled: true
   secrets:

--- a/charts/golang/templates/deployment.yaml
+++ b/charts/golang/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         vault.hashicorp.com/auth-type: "gcp"
         vault.hashicorp.com/auth-config-type: "iam"
         vault.hashicorp.com/auth-config-service-account: {{ .Values.vault.auth.serviceAccount | quote }}
-        vault.hashicorp.com/role: {{ printf "%s-%s-%s" .Values.vault.auth.department .Values.vault.auth.team .Values.fluidtruck.env | quote }}
+        vault.hashicorp.com/role: {{ include "common.vault.role" ( dict "vault" .Values.vault "env" .Values.fluidtruck.env ) | quote }}
         vault.hashicorp.com/agent-inject-secret-newrelic: {{ printf "kv/data/%s/newrelic" .Values.vault.auth.department | quote }}
         {{ printf "vault.hashicorp.com/agent-inject-template-newrelic: |" }}
           {{ printf "{{- with secret \"kv/data/%s/newrelic\" -}}" .Values.vault.auth.department }}
@@ -56,16 +56,16 @@ spec:
           {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
           {{ printf "{{ end -}}" }}
           {{ printf "{{- end -}}" }}
-        vault.hashicorp.com/agent-inject-secret-.env.shared: {{ printf "kv/data/%s/%s/shared" .Values.vault.auth.department .Values.vault.auth.team | quote }}
+        vault.hashicorp.com/agent-inject-secret-.env.shared: {{ printf "kv/data/%s" ( include "common.vault.path" ( dict "vault" .Values.vault "name" "shared" ) ) | quote }}
         {{ printf "vault.hashicorp.com/agent-inject-template-.env.shared: |" }}
-          {{ printf "{{- with secret \"kv/data/%s/%s/shared\" -}}" .Values.vault.auth.department .Values.vault.auth.team }}
+          {{ printf "{{- with secret \"kv/data/%s\" -}}" ( include "common.vault.path" ( dict "vault" .Values.vault "name" "shared" ) ) }}
           {{ printf "{{- range $k, $v := .Data.data -}}" }}
           {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
           {{ printf "{{ end -}}" }}
           {{ printf "{{- end -}}" }}
-        vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s/%s/%s" .Values.vault.auth.department .Values.vault.auth.team .Values.fluidtruck.env | quote }}
+        vault.hashicorp.com/agent-inject-secret-.env: {{ printf "kv/data/%s" ( include "common.vault.path" ( dict "vault" .Values.vault "name" .Values.fluidtruck.env ) ) | quote }}
         {{ printf "vault.hashicorp.com/agent-inject-template-.env: |" }}
-          {{ printf "{{- with secret \"kv/data/%s/%s/%s\" -}}" .Values.vault.auth.department .Values.vault.auth.team .Values.fluidtruck.env }}
+          {{ printf "{{- with secret \"kv/data/%s\" -}}" ( include "common.vault.path" ( dict "vault" .Values.vault "name" .Values.fluidtruck.env ) ) }}
           {{ printf "{{- range $k, $v := .Data.data -}}" }}
           {{ printf "export {{ $k }}=\"{{ $v }}\"" }}
           {{ printf "{{ end -}}" }}

--- a/charts/golang/values.yaml
+++ b/charts/golang/values.yaml
@@ -192,6 +192,7 @@ vault:
   auth:
     department: engineering
     team: devops
+    service: ''
     serviceAccount: soma-sa@project.iam.gserviceaccount.com
   secrets: []
     # The below example will use a standardized template


### PR DESCRIPTION
This consumes the new Vault common helpers. The following scenarios are now possible:

### Empty `vault.auth.service`

By defining the following:

```yaml
fluidtruck:
  env: stage

vault:
  auth:
    department: engineering
    team: backend
    service: ''
```

The following will be generated:

- Role: `engineering-backend-stage`
- Paths: `engineering/backend/shared`, `engineering/backend/stage`

### Defining a service

By defining the following:

```yaml
fluidtruck:
  env: stage

vault:
  auth:
    department: engineering
    team: backend
    service: event-store
```

The following will be generated:

- Role: `engineering-backend-event-store-stage`
- Paths: `engineering/backend/event-store/shared`, `engineering/backend/event-store/stage`