### PR TITLE
chore(golang): upgrade redis

### DIFF
--- a/charts/golang/Chart.lock
+++ b/charts/golang/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.1.28
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 15.7.6
-digest: sha256:b08bc2d88e8d0412b24bd177732c12147865ad930526827ed439499ed10a4127
-generated: "2023-04-04T14:17:31.447961-06:00"
+  version: 17.15.6
+digest: sha256:21a1b081f45392d2c983d136962e0e67d95a5d9d4e77bff4197a2dda1fd53ad6
+generated: "2023-09-19T12:54:05.02404-04:00"

--- a/charts/golang/Chart.yaml
+++ b/charts/golang/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: golang
 description: A chart for Golang.
 icon: https://golang.org/lib/godoc/images/go-logo-blue.svg
-version: 9.2.4
-appVersion: 9.2.4
+version: 9.3.0
+appVersion: 9.3.0
 type: application
 keywords:
   - go
@@ -26,5 +26,5 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     tags:
       - redis
-    version: "15.7.6"
+    version: "17.15.6"
     condition: redis.enabled


### PR DESCRIPTION
* Upgrade version of used redis chart in order to reduce number of security vulnerabilities present on the current cluster
* Version 17.x of the helm chart brings redis from version 6.2 to 7.0 - https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1700